### PR TITLE
Allow dataset data interactives to be reorganized.

### DIFF
--- a/js/codap-handler.js
+++ b/js/codap-handler.js
@@ -15,7 +15,8 @@ const CONFIG = {
     width: 650,
     height: 350
   },
-  version: '0.1'
+  version: '0.1',
+  preventDataContextReorg: false
 }
 
 const DATA_SET_TEMPLATE = {

--- a/public/common/js/CodapInterface.js
+++ b/public/common/js/CodapInterface.js
@@ -243,7 +243,8 @@
           title: iConfig.title,
           version: iConfig.version,
           dimensions: iConfig.dimensions,
-          preventBringToFront: iConfig.preventBringToFront
+          preventBringToFront: iConfig.preventBringToFront,
+          preventDataContextReorg: iConfig.preventDataContextReorg
         };
         var updateFrameReq = {
           action: 'update',


### PR DESCRIPTION
Allow dataset data interactives to be reorganized. Set preventDataContextReorg=false when setting up the interactiveFrame object.
[#160960251]