### PR TITLE
Eliminate use of window.alert to show message

### DIFF
--- a/js/components/simulation-base.js
+++ b/js/components/simulation-base.js
@@ -227,7 +227,7 @@ export default class SimulationBase extends PureComponent {
     const { width, height } = this.props
     if (isRunning && !prevState.isRunning) {
       if (isNaN(this.outputs.totalTime)) {
-        window.alert("Ramp friction is too big, car won't start moving")
+        this.showDialogWithMessage("Ramp friction is too big, car won't start moving")
         this.setState({
           isRunning: false
         })


### PR DESCRIPTION
Eliminate use of window.alert to show message to user.  This is causing embedded fullscreen instances of the app to exit fullscreen.