### PR TITLE
Hide ramp angle display when angle is constant.

### DIFF
--- a/js/components/ramp.js
+++ b/js/components/ramp.js
@@ -3,20 +3,44 @@ import * as c from '../sim-constants'
 import { Group, Text, Line, Arc } from 'react-konva'
 
 export default class Ramp extends PureComponent {
+  renderAngleMark () {
+    const { angle, sx, sy } = this.props
+    const angleInDeg = angle * 180 / Math.PI
+    return (
+      <Group>
+        <Arc
+          x={sx(c.rampEndX)}
+          y={sy(c.rampBottomY)}
+          outerRadius={40}
+          innerRadius={0}
+          fill={'#dddddd'}
+          stroke={0}
+          angle={angleInDeg}
+          rotation={180}
+        />
+        <Text
+          x={sx(c.rampEndX) - 35} y={sy(c.rampBottomY) - 17}
+          fontFamily={'Arial'}
+          fontSize={14}
+          text={Math.round(angleInDeg) + '°'}
+          fill={'black'}
+        />
+      </Group>
+    )
+  }
+
   render () {
-    const { sx, sy, pointX, pointY, angle } = this.props
+    const { sx, sy, pointX, pointY, showAngle } = this.props
     const points = [
       sx(c.rampStartX), sy(pointY),
       sx(c.rampStartX), sy(c.rampBottomY),
       sx(c.rampEndX), sy(c.rampBottomY),
       sx(pointX), sy(pointY)
     ]
-    const angleInDeg = angle * 180 / Math.PI
     return (
       <Group>
         <Line points={points} closed fill={'#959595'} stroke={'black'} strokeWidth={1} />
-        <Arc x={sx(c.rampEndX)} y={sy(c.rampBottomY)} outerRadius={40} innerRadius={0} fill={'#dddddd'} stroke={0} angle={angleInDeg} rotation={180} />
-        <Text x={sx(c.rampEndX) - 35} y={sy(c.rampBottomY) - 17} fontFamily={'Arial'} fontSize={14} text={Math.round(angleInDeg) + '°'} fill={'black'} />
+        {showAngle && this.renderAngleMark()}
       </Group>
     )
   }

--- a/js/components/simulation-base.js
+++ b/js/components/simulation-base.js
@@ -758,7 +758,14 @@ export default class SimulationBase extends PureComponent {
         />
         <Stage width={this.simWidth} height={this.simHeight}>
           <Layer>
-            <Ramp sx={scaleX} sy={scaleY} pointX={rampTopX} pointY={rampTopY} angle={rampAngle} />
+            <Ramp
+              sx={scaleX}
+              sy={scaleY}
+              pointX={rampTopX}
+              pointY={rampTopY}
+              angle={rampAngle}
+              showAngle={allowAngleAdjustment}
+            />
             <Ground sx={scaleX} sy={scaleY} pixelMeterRatio={this.pixelMeterRatio} hideMarks={hideMarks} />
             {
               allowAngleAdjustment && inclineControl &&


### PR DESCRIPTION
@mklewandowski -- It seems like somehow this commit never made it into my pull request.

Would you mind reviewing and possibly releasing again? 

> Remove angle text and grey arc at bottom of hill

[#171655787]
https://www.pivotaltracker.com/story/show/171655787